### PR TITLE
Add some categories to the desktop file

### DIFF
--- a/icebreaker.desktop
+++ b/icebreaker.desktop
@@ -6,3 +6,4 @@ Exec=icebreaker
 Icon=/usr/share/icebreaker/icebreaker_128.png
 Terminal=false
 Keywords=puzzle;game;penguins;ice;
+Categories=Game;LogicGame;


### PR DESCRIPTION
Previously, neither the desktop file nor the metainfo file listed any
categories for this game. This information is used by software centres
to list the game in the right section, and by GNOME Shell to set a good
default name if you drag two games together in the app grid to make a
folder.

Add the two best-fitting categories to the .desktop file. At the point
when the repository's AppStream data is built, these will also get
merged into the metainfo.
