### PR TITLE
Remove -Werror and fix LDFLAGS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifndef bindir
 endif
 
 
-CFLAGS+=-Wall -Werror $(OPTIMIZE) $(SDL_CFLAGS) -DDATAPREFIX=\"$(datadir)/icebreaker\"
+CFLAGS+=-Wall $(OPTIMIZE) $(SDL_CFLAGS) -DDATAPREFIX=\"$(datadir)/icebreaker\"
 
 SRC=icebreaker.c cursor.c grid.c laundry.c line.c penguin.c sound.c \
     level.c intro.c text.c status.c transition.c hiscore.c dialog.c \

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ icebreaker.exe: $(DISTFILES)
 	[ -d win32.build ] && rm -rf win32.build || true
 
 icebreaker:	$(SRC:.c=.o)
-	$(CC) $(CFLAGS) $^ -o icebreaker $(SDL_LIB) $(LDFLAGS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o icebreaker $(SDL_LIB)
 
 man: icebreaker.6
 

--- a/Makefile.w32
+++ b/Makefile.w32
@@ -12,7 +12,7 @@ ifndef OPTIMIZE
   OPTIMIZE=-O2
 endif
 
-CFLAGS=-Wall -Werror -Wno-error=pointer-sign $(OPTIMIZE) $(SDL_CFLAGS) -DDATAPREFIX=\".\" -DHISCOREPREFIX=\".\" -DWIN32 -fstack-protector
+CFLAGS+=-Wall -Wno-error=pointer-sign $(OPTIMIZE) $(SDL_CFLAGS) -DDATAPREFIX=\".\" -DHISCOREPREFIX=\".\" -DWIN32 -fstack-protector
 
 SRC=icebreaker.c cursor.c grid.c laundry.c line.c penguin.c sound.c \
     level.c intro.c text.c status.c transition.c hiscore.c dialog.c \


### PR DESCRIPTION
Distributions don't like `-Werror` because it prevents end users from building the software using newer compilers that may raise warnings you don't know about yet. This is particularly bad for source-based distributions like Gentoo.

Some LDFLAGS need to come before the inputs in order to be effective.